### PR TITLE
Fix broken logo image

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ export const App: React.FunctionComponent = () => {
       gap={15}
     >
       <img
-        src="https://raw.githubusercontent.com/Microsoft/just/master/packages/just-stack-uifabric/template/src/components/fabric.png"
+        src="https://raw.githubusercontent.com/microsoft/just/master/packages/just-stack-uifabric/plop-templates/src/fabric.png"
         alt="logo"
       />
       <Text variant="xxLarge" styles={boldStyle}>


### PR DESCRIPTION
The path to logo image in `App.tsx` appears broken. It was fixed in this PR.

**Before**
![logo-broken](https://user-images.githubusercontent.com/17682302/66427225-716cb400-ea0b-11e9-9601-5730ec995831.png)

**After**
![logo-fixed](https://user-images.githubusercontent.com/17682302/66427258-7cbfdf80-ea0b-11e9-9b6b-a3a21e436a2e.png)
